### PR TITLE
Readme and toolchain improve

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,41 +195,63 @@ Create a file named toolchain.cmake in $HOME/qt6.
 cmake_minimum_required(VERSION 3.18)
 include_guard(GLOBAL)
 
+# -------------------------
+# Target system
+# -------------------------
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
 # You should change location of sysroot to your needs.
-set(TARGET_SYSROOT /home/pmy/rpi-sysroot)
+set(TARGET_SYSROOT /home/kylos/rpi-sysroot)
 set(TARGET_ARCHITECTURE aarch64-linux-gnu)
 set(CMAKE_SYSROOT ${TARGET_SYSROOT})
 
-set(ENV{PKG_CONFIG_PATH} $PKG_CONFIG_PATH:${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig)
+# -------------------------
+# pkg-config setup
+# -------------------------
+# Tell CMake to use cross-compiled pkg-config automatically
+set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig")
 set(ENV{PKG_CONFIG_LIBDIR} /usr/lib/pkgconfig:/usr/share/pkgconfig/:${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig:${TARGET_SYSROOT}/usr/lib/pkgconfig)
 set(ENV{PKG_CONFIG_SYSROOT_DIR} ${CMAKE_SYSROOT})
 
+# -------------------------
+# Cross-compilers
+# -------------------------
 set(CMAKE_C_COMPILER /opt/cross-pi-gcc/bin/${TARGET_ARCHITECTURE}-gcc)
 set(CMAKE_CXX_COMPILER /opt/cross-pi-gcc/bin/${TARGET_ARCHITECTURE}-g++)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem=/usr/include -isystem=/usr/local/include -isystem=/usr/include/${TARGET_ARCHITECTURE}")
+# -------------------------
+# C / C++ flags
+# -------------------------
+set(CMAKE_C_FLAGS "--sysroot=${TARGET_SYSROOT} -O2 -pipe -march=armv8-a -isystem ${TARGET_SYSROOT}/usr/include/${TARGET_ARCHITECTURE}")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
 
+# Optional Qt flags
 set(QT_COMPILER_FLAGS "-march=armv8-a")
 set(QT_COMPILER_FLAGS_RELEASE "-O2 -pipe")
 set(QT_LINKER_FLAGS "-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-rpath-link=${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE} -Wl,-rpath-link=$HOME/qt6/pi/lib")
-
+    
+# -------------------------
+# Library / include paths
+# -------------------------
+set(CMAKE_FIND_ROOT_PATH ${TARGET_SYSROOT})
+set(CMAKE_BUILD_RPATH ${TARGET_SYSROOT})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-set(CMAKE_BUILD_RPATH ${TARGET_SYSROOT})
+
+
+list(APPEND CMAKE_LIBRARY_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE})
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/cmake)
 
 include(CMakeInitializeConfigs)
 
 function(cmake_initialize_per_config_variable _PREFIX _DOCSTRING)
   if (_PREFIX MATCHES "CMAKE_(C|CXX|ASM)_FLAGS")
     set(CMAKE_${CMAKE_MATCH_1}_FLAGS_INIT "${QT_COMPILER_FLAGS}")
-        
+
     foreach (config DEBUG RELEASE MINSIZEREL RELWITHDEBINFO)
       if (DEFINED QT_COMPILER_FLAGS_${config})
         set(CMAKE_${CMAKE_MATCH_1}_FLAGS_${config}_INIT "${QT_COMPILER_FLAGS_${config}}")
@@ -247,34 +269,18 @@ function(cmake_initialize_per_config_variable _PREFIX _DOCSTRING)
   _cmake_initialize_per_config_variable(${ARGV})
 endfunction()
 
-set(XCB_PATH_VARIABLE ${TARGET_SYSROOT})
+# -------------------------
+# OpenGL / EGL / GBM / XCB libraries
+# -------------------------
 
-set(GL_INC_DIR ${TARGET_SYSROOT}/usr/include)
-set(GL_LIB_DIR ${TARGET_SYSROOT}:${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/:${TARGET_SYSROOT}/usr:${TARGET_SYSROOT}/usr/lib)
+# Keep the sysroot library paths, but remove explicit inclusion of system headers
+set(EGL_LIBRARY   ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libEGL.so)
+set(OPENGL_opengl_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libOpenGL.so)
+set(GLESv2_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
+set(gbm_LIBRARY   ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libgbm.so)
+set(Libdrm_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libdrm.so)
+set(XCB_XCB_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libxcb.so)
 
-set(EGL_INCLUDE_DIR ${GL_INC_DIR})
-set(EGL_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libEGL.so)
-
-set(OPENGL_INCLUDE_DIR ${GL_INC_DIR})
-set(OPENGL_opengl_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libOpenGL.so)
-
-set(GLESv2_INCLUDE_DIR ${GL_INC_DIR})
-set(GLIB_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
-
-set(GLESv2_INCLUDE_DIR ${GL_INC_DIR})
-set(GLESv2_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
-
-set(gbm_INCLUDE_DIR ${GL_INC_DIR})
-set(gbm_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libgbm.so)
-
-set(Libdrm_INCLUDE_DIR ${GL_INC_DIR})
-set(Libdrm_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libdrm.so)
-
-set(XCB_XCB_INCLUDE_DIR ${GL_INC_DIR})
-set(XCB_XCB_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libxcb.so)
-
-list(APPEND CMAKE_LIBRARY_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE})
-list(APPEND CMAKE_PREFIX_PATH "/usr/lib/${TARGET_ARCHITECTURE}/cmake")
 ```
 Fix absolute symbolic links
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Click the follow image to view this tutorial on Youtube.
 - Localization https://youtu.be/JtTtzYZ_Nk0
 
 # Prepare RPI
-Install the lastest 64bit Raspberry Pi OS with desktop and update the system. Before making an upgrade we will put on hold the installation of libqt6* libraries, these libraries. 
+Install the lastest 64bit Raspberry Pi OS with desktop and update the system. 
+
+Before making an upgrade we will put on hold the installation of libqt6* libraries, these libraries can conflict with our qt creator installation that will be done later. 
 
 Note : (During the upgrade you will be asked (Y/N) whether new packages will be installed. If a new package Qt6 is proposed, abort the installation and add it to the sudo apt-mark hold as listed below)
 ```
@@ -190,12 +192,13 @@ cmake --install .
 Binaries will be in $HOME/qt6/host
 ### Build Qt6 for rpi
 copy and paste a few folders from rpi using rsync through SSH. **You should modify the following commands to your needs.**
+Name of your board = raspberrypi or its ip address 192.168.6.218
 ```
 cd ~
-rsync -avz --rsync-path="sudo rsync" pi@192.168.6.218:/usr/include rpi-sysroot/usr
-rsync -avz --rsync-path="sudo rsync" pi@192.168.6.218:/lib rpi-sysroot
-rsync -avz --rsync-path="sudo rsync" pi@192.168.6.218:/usr/lib rpi-sysroot/usr 
-rsync -avz --rsync-path="sudo rsync" pi@192.168.6.218:/opt/vc rpi-sysroot/opt
+rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/usr/include rpi-sysroot/usr
+rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/lib rpi-sysroot
+rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/usr/lib rpi-sysroot/usr 
+rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/opt/vc rpi-sysroot/opt
 ```
 Create a file named toolchain.cmake in $HOME/qt6.
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cross compilation of Qt6.5.1 for RPI
-This page shows steps to compile Qt6.5.1 for RPI. Hope this page will help those stuck at following official tutorial. Before start, it is highly recommended that you use the same Ubuntu 22.04. At least not the older one. 
+This page shows steps to compile Qt6.5.1 for RPI. Hope this page will help those stuck at following official tutorial. Before start, it is highly recommended that you use the same Ubuntu 22.04 At least not the older one. 
 
 Click the follow image to view this tutorial on Youtube.
 
@@ -45,6 +45,7 @@ sudo chmod 777 /usr/local/bin
 Remember versions of gcc(10.2.1), ld(2.35.2) and ldd(2.31). Source code of the same version should be downloaded to build cross compiler later.
 
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/ba2f1848-0c5c-426d-8d3f-1420931637bd)
+<img width="743" height="380" alt="gcc_ld_ldd" src="https://github.com/user-attachments/assets/6bfa8731-fa5c-4dbc-8da8-07363838abef" />
 
 Append following piece of code to the end of ~/.bashrc.
 ```
@@ -55,7 +56,7 @@ Update the changes.
 source ~/.bashrc
 ```
 # Prepare host
-Create a virtual machine for Ubuntu 22.04.2 and then update the system.
+Create a virtual machine for Ubuntu 22.04.5 and then update the system.
 ```
 sudo apt update
 sudo apt upgrade
@@ -192,7 +193,7 @@ cmake --install .
 Binaries will be in $HOME/qt6/host
 ### Build Qt6 for rpi
 copy and paste a few folders from rpi using rsync through SSH. **You should modify the following commands to your needs.**
-Name of your board = raspberrypi or its ip address 192.168.6.218
+For this example the name of the board is raspberrypi 
 ```
 cd ~
 rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/usr/include rpi-sysroot/usr
@@ -308,34 +309,44 @@ cmake --install .
 ```
 Send the binaries to rpi. **You should modify the following commands to your needs.**
 ```
-rsync -avz --rsync-path="sudo rsync" $HOME/qt6/pi/* pi@192.168.6.218:/usr/local/qt6
+rsync -avz --rsync-path="sudo rsync" $HOME/qt6/pi/* pi@raspberrypi.local:/usr/local/qt6
 ```
 ## With Qt Creator
 Set up **Compilers**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/e98645c4-cf99-45e3-a8b4-ecc0899d6fa0)
+<img width="1247" height="790" alt="Compilers" src="https://github.com/user-attachments/assets/08fd1206-b086-4338-ba0e-11e5720271d7" />
+
 
 Set up **Debuggers**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/f75adf17-b8eb-4149-a5fc-cf59978aa3d9)
+<img width="1247" height="790" alt="Debuggers" src="https://github.com/user-attachments/assets/eb328b47-1cd4-448f-a432-c2274bcc66e3" />
+
 
 Set up **Devices**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/57609ea4-6901-41a8-8264-c6bb7aeac844)
+<img width="1250" height="787" alt="Devices" src="https://github.com/user-attachments/assets/6468cafd-b22b-4ebf-b78f-9e1eabc02a52" />
 
 Click **Deploy Public Key...** to deploy the key. Create one if not existed.
 
 Test the device.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/9883e600-7963-48e3-98fc-dc3f2e651bff)
+<img width="1247" height="790" alt="Device_test" src="https://github.com/user-attachments/assets/3d77b6af-1dcf-4fef-bec5-39c6c2a2420f" />
+
 
 Set up **Qt Versions**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/6c43b6f0-a256-4d2d-86f6-80bb393602af)
+<img width="1250" height="787" alt="Qt_versions" src="https://github.com/user-attachments/assets/55fae848-eee2-4b4c-a762-0a082124e3b6" />
 
 Set up **Kits**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/93e04b07-7cbc-43d6-a17c-53fe6d272de9)
+<img width="1250" height="787" alt="Kits_cmake_conf" src="https://github.com/user-attachments/assets/64a6f348-2338-45c6-8e86-401004d3803a" />
 
-On **CMake Configuration** opton, click Change and add follow commands. **You should modify the following commands to your needs.**
+On **CMake Configuration** option, click Change and add follow commands. **You should modify the following commands to your needs.**
 ```
 -DCMAKE_TOOLCHAIN_FILE:UNINITIALIZED=/home/pmy/qt6/pi/lib/cmake/Qt6/qt.toolchain.cmake
 ```
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/d7c4600a-7058-4541-bdfd-ce184e7fd94c)
+<img width="1250" height="787" alt="Kits_cmake_conf" src="https://github.com/user-attachments/assets/ae4c3807-56e2-4e0d-89a0-63ac8876933d" />
+
 
 ## Test HelloWorld
 On **Help** option select **About Plugins**.Then uncheck **ClangCodeModel**(**No need for Qt Creator 10 or later**)..
@@ -353,6 +364,7 @@ install(TARGETS HelloWorld
 Goto **Projects**
 Under **Run** section, on **X11 Forwarding** check **Forward to local display** and input :0 to the text field. 
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/b396954b-fb04-48ae-a3c4-8ae67178513e)
+<img width="1509" height="703" alt="Project_run_config" src="https://github.com/user-attachments/assets/584dab5d-d22f-4712-af5a-e4c688093210" />
 
 Under **Environment** section, click **Details** to expand the environment option. Click **Add**, then on **Variable** column type **LD_LIBRARY_PATH**. On the **Value** column, type **:/usr/local/qt6/lib/**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/059f275c-bfa4-4357-b4b6-82880b5c1054)

--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ Grant full access to the fold used for the deployment from Qt Creator.
 ```
 sudo chmod 777 /usr/local/bin
 ```
-Remember versions of gcc(10.2.1), ld(2.35.2) and ldd(2.31). Source code of the same version should be downloaded to build cross compiler later.
+Remember versions of gcc(12.2.0), ld(2.40) and ldd(2.36). Source code of the same version should be downloaded to build cross compiler later.
 
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/ba2f1848-0c5c-426d-8d3f-1420931637bd)
 <img width="743" height="380" alt="gcc_ld_ldd" src="https://github.com/user-attachments/assets/6bfa8731-fa5c-4dbc-8da8-07363838abef" />
 
 Append following piece of code to the end of ~/.bashrc.
@@ -317,27 +316,21 @@ Set up **Compilers**.
 
 
 Set up **Debuggers**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/f75adf17-b8eb-4149-a5fc-cf59978aa3d9)
 <img width="1247" height="790" alt="Debuggers" src="https://github.com/user-attachments/assets/eb328b47-1cd4-448f-a432-c2274bcc66e3" />
 
-
 Set up **Devices**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/57609ea4-6901-41a8-8264-c6bb7aeac844)
 <img width="1250" height="787" alt="Devices" src="https://github.com/user-attachments/assets/6468cafd-b22b-4ebf-b78f-9e1eabc02a52" />
 
 Click **Deploy Public Key...** to deploy the key. Create one if not existed.
 
 Test the device.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/9883e600-7963-48e3-98fc-dc3f2e651bff)
 <img width="1247" height="790" alt="Device_test" src="https://github.com/user-attachments/assets/3d77b6af-1dcf-4fef-bec5-39c6c2a2420f" />
 
 
 Set up **Qt Versions**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/6c43b6f0-a256-4d2d-86f6-80bb393602af)
 <img width="1250" height="787" alt="Qt_versions" src="https://github.com/user-attachments/assets/55fae848-eee2-4b4c-a762-0a082124e3b6" />
 
 Set up **Kits**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/93e04b07-7cbc-43d6-a17c-53fe6d272de9)
 <img width="1250" height="787" alt="Kits_RPI" src="https://github.com/user-attachments/assets/d0f60579-8adc-47ec-86da-92af22361abf" />
 
 
@@ -345,7 +338,6 @@ On **CMake Configuration** option, click Change and add follow commands. **You s
 ```
 -DCMAKE_TOOLCHAIN_FILE:UNINITIALIZED=/home/pmy/qt6/pi/lib/cmake/Qt6/qt.toolchain.cmake
 ```
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/d7c4600a-7058-4541-bdfd-ce184e7fd94c)
 <img width="1250" height="787" alt="Kits_cmake_conf" src="https://github.com/user-attachments/assets/ae4c3807-56e2-4e0d-89a0-63ac8876933d" />
 
 
@@ -364,11 +356,9 @@ install(TARGETS HelloWorld
 ```
 Goto **Projects**
 Under **Run** section, on **X11 Forwarding** check **Forward to local display** and input :0 to the text field. 
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/b396954b-fb04-48ae-a3c4-8ae67178513e)
 <img width="1509" height="703" alt="Project_run_config" src="https://github.com/user-attachments/assets/584dab5d-d22f-4712-af5a-e4c688093210" />
 
 Under **Environment** section, click **Details** to expand the environment option. Click **Add**, then on **Variable** column type **LD_LIBRARY_PATH**. On the **Value** column, type **:/usr/local/qt6/lib/**.
-![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/059f275c-bfa4-4357-b4b6-82880b5c1054)
 <img width="1442" height="724" alt="Environment_Variable" src="https://github.com/user-attachments/assets/86dfc3fb-54c5-42c7-986c-f0e4ed465911" />
 
 Run.

--- a/README.md
+++ b/README.md
@@ -76,21 +76,21 @@ Folder CMake is not need any more. You can delete it.
 ## Build gcc as a cross compiler
 Download necessary source code. **You should modify the following commands to your needs.**
 For the time I make this page, they are:
-* gcc 10.3.0(gcc version 10.2.1 does not exist and use the closest one)
-* binutils 2.35.2(ld version)
-* glibc 2.31(ldd version)
+* gcc 12.2.0(gcc version 12.2.0 does not exist and use the closest one)
+* binutils 2.40 (ld version)
+* glibc 2.36 (ldd version)
 ```
 cd ~
 mkdir gcc_all && cd gcc_all
-wget https://ftpmirror.gnu.org/binutils/binutils-2.35.2.tar.bz2
-wget https://ftpmirror.gnu.org/glibc/glibc-2.31.tar.bz2
-wget https://ftpmirror.gnu.org/gcc/gcc-10.3.0/gcc-10.3.0.tar.gz
+wget https://ftpmirror.gnu.org/binutils/binutils-2.40.tar.bz2
+wget https://ftpmirror.gnu.org/glibc/glibc-2.36.tar.bz2
+wget https://ftpmirror.gnu.org/gcc/gcc-12.2.0/gcc-12.2.0.tar.gz
 git clone --depth=1 https://github.com/raspberrypi/linux
-tar xf binutils-2.35.2.tar.bz2
-tar xf glibc-2.31.tar.bz2
-tar xf gcc-10.3.0.tar.gz
+tar xf binutils-2.40.tar.bz2
+tar xf glibc-2.36.tar.bz2
+tar xf gcc-12.2.0.tar.gz
 rm *.tar.*
-cd gcc-10.3.0
+cd gcc-12.2.0
 contrib/download_prerequisites
 ```
 Make a folder for the compiler installation.
@@ -110,11 +110,11 @@ Build Binutils. **You should modify the following commands to your needs.**
 ```
 cd ~/gcc_all
 mkdir build-binutils && cd build-binutils
-../binutils-2.35.2/configure --prefix=/opt/cross-pi-gcc --target=aarch64-linux-gnu --with-arch=armv8 --disable-multilib
+../binutils-2.40/configure --prefix=/opt/cross-pi-gcc --target=aarch64-linux-gnu --with-arch=armv8 --disable-multilib
 make -j 8
 make install
 ```
-Edit gcc-10.3.0/libsanitizer/asan/asan_linux.cpp. Add following piece of code.
+Edit gcc-12.2.0/libsanitizer/asan/asan_linux.cpp. Add following piece of code.
 ```
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -125,7 +125,7 @@ Do a partial build of gcc. **You should modify the following commands to your ne
 ```
 cd ~/gcc_all
 mkdir build-gcc && cd build-gcc
-../gcc-10.3.0/configure --prefix=/opt/cross-pi-gcc --target=aarch64-linux-gnu --enable-languages=c,c++ --disable-multilib
+../gcc-12.2.0/configure --prefix=/opt/cross-pi-gcc --target=aarch64-linux-gnu --enable-languages=c,c++ --disable-multilib
 make -j8 all-gcc
 make install-gcc
 ```
@@ -133,7 +133,14 @@ Partially build Glibc. **You should modify the following commands to your needs.
 ```
 cd ~/gcc_all
 mkdir build-glibc && cd build-glibc
-../glibc-2.31/configure --prefix=/opt/cross-pi-gcc/aarch64-linux-gnu --build=$MACHTYPE --host=aarch64-linux-gnu --target=aarch64-linux-gnu --with-headers=/opt/cross-pi-gcc/aarch64-linux-gnu/include --disable-multilib libc_cv_forced_unwind=yes
+../glibc-2.36/configure \
+  --prefix=/opt/cross-pi-gcc/aarch64-linux-gnu \
+  --build=$MACHTYPE \
+  --host=aarch64-linux-gnu \
+  --target=aarch64-linux-gnu \
+  --with-headers=/opt/cross-pi-gcc/aarch64-linux-gnu/include \
+  --disable-multilib \
+  libc_cv_forced_unwind=yes
 make install-bootstrap-headers=yes install-headers
 make -j8 csu/subdir_lib
 install csu/crt1.o csu/crti.o csu/crtn.o /opt/cross-pi-gcc/aarch64-linux-gnu/lib

--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Click the follow image to view this tutorial on Youtube.
 - Localization https://youtu.be/JtTtzYZ_Nk0
 
 # Prepare RPI
-Install the lastest 64bit Raspberry Pi OS with desktop and update the system.
+Install the lastest 64bit Raspberry Pi OS with desktop and update the system. Before making an upgrade we will put on hold the installation of libqt6* libraries, these libraries. 
+
+Note : (During the upgrade you will be asked (Y/N) whether new packages will be installed. If a new package Qt6 is proposed, abort the installation and add it to the sudo apt-mark hold as listed below)
 ```
 sudo apt update
+sudo apt-mark hold libqt6core6 libqt6dbus6 libqt6gui6 libqt6network6 libqt6opengl6 libqt6openglwidgets6 libqt6widgets6 qt6-gtk-platformtheme qt6-qpa-plugins qt6-translations-l10n
 sudo apt upgrade
 sudo reboot
 ```
@@ -22,6 +25,12 @@ sudo apt-get install libboost-all-dev libudev-dev libinput-dev libts-dev libmtde
 ```
 ```
 sudo apt-get install libavcodec-dev libavformat-dev libswscale-dev libx11-dev freetds-dev libsqlite3-dev libpq-dev libiodbc2-dev firebird-dev libxext-dev libxcb1 libxcb1-dev libx11-xcb1 libx11-xcb-dev libxcb-keysyms1 libxcb-keysyms1-dev libxcb-image0 libxcb-image0-dev libxcb-shm0 libxcb-shm0-dev libxcb-icccm4 libxcb-icccm4-dev libxcb-sync1 libxcb-sync-dev libxcb-render-util0 libxcb-render-util0-dev libxcb-xfixes0-dev libxrender-dev libxcb-shape0-dev libxcb-randr0-dev libxcb-glx0-dev libxi-dev libdrm-dev libxcb-xinerama0 libxcb-xinerama0-dev libatspi2.0-dev libxcursor-dev libxcomposite-dev libxdamage-dev libxss-dev libxtst-dev libpci-dev libcap-dev libxrandr-dev libdirectfb-dev libaudio-dev libxkbcommon-x11-dev gdbserver
+```
+Standard UTF-8 for Qt creator compatibility
+```
+sudo locale-gen en_GB.UTF-8
+sudo update-locale LANG=en_GB.UTF-8 LC_ALL=en_GB.UTF-8
+sudo reboot
 ```
 Make a folder for qt6 installation.
 ```

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ copy and paste a few folders from rpi using rsync through SSH. **You should modi
 For this example the name of the board is raspberrypi 
 ```
 cd ~
-rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/usr/include rpi-sysroot/usr
-rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/lib rpi-sysroot
-rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/usr/lib rpi-sysroot/usr 
-rsync -avz --rsync-path="sudo rsync" pi@raspberry.local:/opt/vc rpi-sysroot/opt
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/usr/include rpi-sysroot/usr
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/lib rpi-sysroot
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/usr/lib rpi-sysroot/usr 
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/opt/vc rpi-sysroot/opt
 ```
 Create a file named toolchain.cmake in $HOME/qt6.
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Click the follow image to view this tutorial on Youtube.
 # Prepare RPI
 Install the lastest 64bit Raspberry Pi OS with desktop and update the system. 
 
-Before making an upgrade we will put on hold the installation of libqt6* libraries, these libraries can conflict with our qt creator installation that will be done later. 
+Before making an upgrade we will put on hold the installation of libqt6* libraries. Tests have shown that these libraries conflict with the Qt Creator installation planned for later. 
 
 Note : (During the upgrade you will be asked (Y/N) whether new packages will be installed. If a new package Qt6 is proposed, abort the installation and add it to the sudo apt-mark hold as listed below)
 ```
@@ -338,7 +338,8 @@ Set up **Qt Versions**.
 
 Set up **Kits**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/93e04b07-7cbc-43d6-a17c-53fe6d272de9)
-<img width="1250" height="787" alt="Kits_cmake_conf" src="https://github.com/user-attachments/assets/64a6f348-2338-45c6-8e86-401004d3803a" />
+<img width="1250" height="787" alt="Kits_RPI" src="https://github.com/user-attachments/assets/d0f60579-8adc-47ec-86da-92af22361abf" />
+
 
 On **CMake Configuration** option, click Change and add follow commands. **You should modify the following commands to your needs.**
 ```
@@ -368,6 +369,7 @@ Under **Run** section, on **X11 Forwarding** check **Forward to local display** 
 
 Under **Environment** section, click **Details** to expand the environment option. Click **Add**, then on **Variable** column type **LD_LIBRARY_PATH**. On the **Value** column, type **:/usr/local/qt6/lib/**.
 ![image](https://github.com/MuyePan/CrossCompileQtForRpi/assets/136073506/059f275c-bfa4-4357-b4b6-82880b5c1054)
+<img width="1442" height="724" alt="Environment_Variable" src="https://github.com/user-attachments/assets/86dfc3fb-54c5-42c7-986c-f0e4ed465911" />
 
 Run.
 

--- a/rpi_pi-build.sh
+++ b/rpi_pi-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Script to sync Raspberry Pi system Qt6 binaries
+
+# Automatically detect current user
+USER_HOME="/home/$USER"
+
+# Go to qt6 directory
+cd "$USER_HOME/qt6" || exit 1
+
+rm -rf pi-build
+mkdir pi-build && cd pi-build || exit 1
+
+# Cmake command to configure using raspberrypi sysroot
+cd pi-build
+cmake ../src/qtbase-everywhere-src-6.5.1/ -GNinja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DINPUT_opengl=es2 \
+  -DQT_BUILD_EXAMPLES=OFF \
+  -DQT_BUILD_TESTS=OFF \
+  -DQT_HOST_PATH=$HOME/qt6/host \
+  -DCMAKE_STAGING_PREFIX=$HOME/qt6/pi \
+  -DCMAKE_INSTALL_PREFIX=/usr/local/qt6 \
+  -DCMAKE_TOOLCHAIN_FILE=$HOME/qt6/toolchain.cmake \
+  -DQT_QMAKE_TARGET_MKSPEC=devices/linux-rasp-pi4-aarch64 \
+  -DQT_FEATURE_xcb=ON \
+  -DFEATURE_xcb_xlib=ON \
+  -DQT_FEATURE_xlib=ON
+
+if cmake --build . --parallel 8 && cmake --install .; then
+    echo "Build successful. Sending binaries to raspberrypi..."
+    rsync -avz --delete --rsync-path="sudo rsync" $HOME/qt6/pi/ pi@raspberrypi.local:/usr/local/qt6
+else
+    echo "Build failed. Not syncing binaries."
+    exit 1
+fi

--- a/rpi_sync_sysroot.sh
+++ b/rpi_sync_sysroot.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Script to sync Raspberry Pi system directories using hostname
+
+# Go to home directory
+cd ~
+sudo rm -rf rpi-sysroot
+
+# Define target directories
+TARGET_BASE="rpi-sysroot"
+DIRS=("/usr" "/lib" "/usr/lib" "/opt")
+
+# Create base directory if it doesn't exist
+mkdir -p "$TARGET_BASE"
+
+# Create required subdirectories
+for dir in "${DIRS[@]}"; do
+    mkdir -p "$TARGET_BASE$dir"
+done
+# Sync directories from Raspberry Pi using raspberrypi.local
+# Change raspberrypi by the name of your board
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/usr/include "$TARGET_BASE/usr"
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/lib "$TARGET_BASE"
+rsync -avz --rsync-path="sudo rsync" pi@raspberrypi.local:/usr/lib "$TARGET_BASE/usr"
+
+
+#Fix absolute symbolic links
+# Check if the file already exists
+if [ ! -f sysroot-relativelinks.py ]; then
+    wget https://raw.githubusercontent.com/riscv/riscv-poky/master/scripts/sysroot-relativelinks.py
+else
+    echo "sysroot-relativelinks.py already exists, skipping download."
+fi
+
+# Make the script executable
+chmod +x sysroot-relativelinks.py 
+
+# Run the Python script
+python3 sysroot-relativelinks.py rpi-sysroot

--- a/toolchain.cmake
+++ b/toolchain.cmake
@@ -1,41 +1,63 @@
 cmake_minimum_required(VERSION 3.18)
 include_guard(GLOBAL)
 
+# -------------------------
+# Target system
+# -------------------------
 set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_SYSTEM_PROCESSOR arm)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
-# You should change location of sysroot to your needs.
-set(TARGET_SYSROOT /home/pmy/rpi-sysroot)
+# Sysroot for the Raspberry Pi
+set(TARGET_SYSROOT /home/kylos/rpi-sysroot)
 set(TARGET_ARCHITECTURE aarch64-linux-gnu)
 set(CMAKE_SYSROOT ${TARGET_SYSROOT})
 
-set(ENV{PKG_CONFIG_PATH} $PKG_CONFIG_PATH:${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig)
+# -------------------------
+# pkg-config setup
+# -------------------------
+# Tell CMake to use cross-compiled pkg-config automatically
+set(ENV{PKG_CONFIG_PATH} "$ENV{PKG_CONFIG_PATH}:${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig")
 set(ENV{PKG_CONFIG_LIBDIR} /usr/lib/pkgconfig:/usr/share/pkgconfig/:${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/pkgconfig:${TARGET_SYSROOT}/usr/lib/pkgconfig)
 set(ENV{PKG_CONFIG_SYSROOT_DIR} ${CMAKE_SYSROOT})
 
+# -------------------------
+# Cross-compilers
+# -------------------------
 set(CMAKE_C_COMPILER /opt/cross-pi-gcc/bin/${TARGET_ARCHITECTURE}-gcc)
 set(CMAKE_CXX_COMPILER /opt/cross-pi-gcc/bin/${TARGET_ARCHITECTURE}-g++)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem=/usr/include -isystem=/usr/local/include -isystem=/usr/include/${TARGET_ARCHITECTURE}")
+# -------------------------
+# C / C++ flags
+# -------------------------
+set(CMAKE_C_FLAGS "--sysroot=${TARGET_SYSROOT} -O2 -pipe -march=armv8-a -isystem ${TARGET_SYSROOT}/usr/include/${TARGET_ARCHITECTURE}")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS}")
 
+# Optional Qt flags
 set(QT_COMPILER_FLAGS "-march=armv8-a")
 set(QT_COMPILER_FLAGS_RELEASE "-O2 -pipe")
 set(QT_LINKER_FLAGS "-Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed -Wl,-rpath-link=${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE} -Wl,-rpath-link=$HOME/qt6/pi/lib")
-
+    
+# -------------------------
+# Library / include paths
+# -------------------------
+set(CMAKE_FIND_ROOT_PATH ${TARGET_SYSROOT})
+set(CMAKE_BUILD_RPATH ${TARGET_SYSROOT})
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-set(CMAKE_BUILD_RPATH ${TARGET_SYSROOT})
+
+
+list(APPEND CMAKE_LIBRARY_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE})
+list(APPEND CMAKE_PREFIX_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/cmake)
 
 include(CMakeInitializeConfigs)
 
 function(cmake_initialize_per_config_variable _PREFIX _DOCSTRING)
   if (_PREFIX MATCHES "CMAKE_(C|CXX|ASM)_FLAGS")
     set(CMAKE_${CMAKE_MATCH_1}_FLAGS_INIT "${QT_COMPILER_FLAGS}")
-        
+
     foreach (config DEBUG RELEASE MINSIZEREL RELWITHDEBINFO)
       if (DEFINED QT_COMPILER_FLAGS_${config})
         set(CMAKE_${CMAKE_MATCH_1}_FLAGS_${config}_INIT "${QT_COMPILER_FLAGS_${config}}")
@@ -53,31 +75,14 @@ function(cmake_initialize_per_config_variable _PREFIX _DOCSTRING)
   _cmake_initialize_per_config_variable(${ARGV})
 endfunction()
 
-set(XCB_PATH_VARIABLE ${TARGET_SYSROOT})
+# -------------------------
+# OpenGL / EGL / GBM / XCB libraries
+# -------------------------
 
-set(GL_INC_DIR ${TARGET_SYSROOT}/usr/include)
-set(GL_LIB_DIR ${TARGET_SYSROOT}:${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/:${TARGET_SYSROOT}/usr:${TARGET_SYSROOT}/usr/lib)
-
-set(EGL_INCLUDE_DIR ${GL_INC_DIR})
-set(EGL_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libEGL.so)
-
-set(OPENGL_INCLUDE_DIR ${GL_INC_DIR})
-set(OPENGL_opengl_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libOpenGL.so)
-
-set(GLESv2_INCLUDE_DIR ${GL_INC_DIR})
-set(GLIB_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
-
-set(GLESv2_INCLUDE_DIR ${GL_INC_DIR})
-set(GLESv2_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
-
-set(gbm_INCLUDE_DIR ${GL_INC_DIR})
-set(gbm_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libgbm.so)
-
-set(Libdrm_INCLUDE_DIR ${GL_INC_DIR})
-set(Libdrm_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libdrm.so)
-
-set(XCB_XCB_INCLUDE_DIR ${GL_INC_DIR})
-set(XCB_XCB_LIBRARY ${XCB_PATH_VARIABLE}/usr/lib/${TARGET_ARCHITECTURE}/libxcb.so)
-
-list(APPEND CMAKE_LIBRARY_PATH ${CMAKE_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE})
-list(APPEND CMAKE_PREFIX_PATH "/usr/lib/${TARGET_ARCHITECTURE}/cmake")
+# Keep the sysroot library paths, but remove explicit inclusion of system headers
+set(EGL_LIBRARY   ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libEGL.so)
+set(OPENGL_opengl_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libOpenGL.so)
+set(GLESv2_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libGLESv2.so)
+set(gbm_LIBRARY   ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libgbm.so)
+set(Libdrm_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libdrm.so)
+set(XCB_XCB_LIBRARY ${TARGET_SYSROOT}/usr/lib/${TARGET_ARCHITECTURE}/libxcb.so)


### PR DESCRIPTION
Correct architecture (aarch64 vs arm) — ensures proper headers and libraries are picked.

Proper CMAKE_FIND_ROOT_PATH — ensures sysroot is searched before host paths.

Sysroot-first include flags (-isystem ${TARGET_SYSROOT}/usr/include/...) — avoids mixing host headers.

Correct library and cmake paths — ensures the cross-compiled libs are found.

Pkg-config uses sysroot — avoids pulling host packages.